### PR TITLE
fix: ignore QUNS_BUSY in ShouldProcessGetSelection

### DIFF
--- a/src/windows/selection_hook.cc
+++ b/src/windows/selection_hook.cc
@@ -1328,7 +1328,7 @@ bool SelectionHook::ShouldProcessGetSelection()
     // QUNS_BUSY (2) - System is busy
     // QUNS_RUNNING_D3D_FULL_SCREEN (3) - Running in full-screen mode
     // QUNS_PRESENTATION_MODE (4) - Presentation mode
-    lastResult = state != QUNS_RUNNING_D3D_FULL_SCREEN && state != QUNS_BUSY && state != QUNS_PRESENTATION_MODE;
+    lastResult = state != QUNS_RUNNING_D3D_FULL_SCREEN && state != QUNS_PRESENTATION_MODE;
     return lastResult;
 }
 


### PR DESCRIPTION
修复 windows 进入钉钉会议共享屏幕后划词会失效