### PR TITLE
fix(mac): stop gating drag selection detection on cursor shape

### DIFF
--- a/src/mac/selection_hook.mm
+++ b/src/mac/selection_hook.mm
@@ -250,6 +250,13 @@ class SelectionHook : public Napi::ObjectWrap<SelectionHook>
 
     bool is_triggered_by_user = false;  // user use GetCurrentSelection
 
+    // Whether the current mouse gesture ever showed an I-beam cursor
+    // (at mouse-down, mid-drag or mouse-up). AX reads are side-effect free
+    // and no longer gated on cursor shape, but the clipboard fallback
+    // simulates Cmd+C, so it stays gated on this evidence (see GetSelectedText),
+    // matching the Windows implementation.
+    bool gesture_has_cursor_evidence = true;
+
     bool is_enabled_mouse_move_event = false;
 
     // passive mode: only trigger when user call GetSelectionText
@@ -820,8 +827,11 @@ bool SelectionHook::GetSelectedText(NSRunningApplication *frontApp, TextSelectio
         result = true;
     }
 
-    // Last resort: try to get text using clipboard and Cmd+C if enabled
-    if (!result && ShouldProcessViaClipboard(selectionInfo.programName) && GetTextViaClipboard(frontApp, selectionInfo))
+    // Last resort: try to get text using clipboard and Cmd+C if enabled.
+    // Simulating Cmd+C has side effects, so unlike the AX read it requires cursor
+    // evidence for the gesture (user-triggered reads cannot know the cursor shape).
+    if (!result && (is_triggered_by_user || gesture_has_cursor_evidence) &&
+        ShouldProcessViaClipboard(selectionInfo.programName) && GetTextViaClipboard(frontApp, selectionInfo))
     {
         selectionInfo.method = SelectionMethod::Clipboard;
         result = true;
@@ -1675,6 +1685,7 @@ void SelectionHook::ProcessMouseEvent(Napi::Env env, Napi::Function function, Mo
     static uint64_t lastMouseDownTime = 0;            // Last mouse down time
     static bool isLastValidClick = false;
     static bool isLastMouseDownValidCursor = false;
+    static bool wasIBeamDuringDrag = false;
 
     bool shouldDetectSelection = false;
 
@@ -1692,6 +1703,7 @@ void SelectionHook::ProcessMouseEvent(Napi::Env env, Napi::Function function, Mo
             lastMouseDownTime = currentTime;
             lastMouseDownPos = currentPos;
             isLastMouseDownValidCursor = IsIBeamCursor([NSCursor currentSystemCursor]);
+            wasIBeamDuringDrag = false;
             currentInstance->clipboard_sequence = GetClipboardSequence();
             break;
         }
@@ -1707,7 +1719,9 @@ void SelectionHook::ProcessMouseEvent(Napi::Env env, Napi::Function function, Mo
                 double distance = sqrt(dx * dx + dy * dy);
 
                 bool isCurrentValidClick = (currentTime - lastMouseDownTime) <= DOUBLE_CLICK_TIME_MS;
-                bool isValidCursor = isLastMouseDownValidCursor || IsIBeamCursor([NSCursor currentSystemCursor]);
+                bool isValidCursor = isLastMouseDownValidCursor || wasIBeamDuringDrag ||
+                                     IsIBeamCursor([NSCursor currentSystemCursor]);
+                currentInstance->gesture_has_cursor_evidence = isValidCursor;
 
                 if ((currentTime - lastMouseDownTime) > MAX_DRAG_TIME_MS)
                 {
@@ -1716,12 +1730,13 @@ void SelectionHook::ProcessMouseEvent(Napi::Env env, Napi::Function function, Mo
                 // Check for drag selection
                 else if (distance >= MIN_DRAG_DISTANCE)
                 {
-                    // Only support IBeamCursor for now
-                    if (isValidCursor)
-                    {
-                        shouldDetectSelection = true;
-                        detectionType = SelectionDetectType::Drag;
-                    }
+                    // No cursor gating for drags: during a fast drag macOS may never
+                    // update the cursor to I-beam at all (cursor updates lag until the
+                    // pointer rests), so gating on cursor shape drops valid selections.
+                    // The AX read is side-effect free; only the clipboard fallback
+                    // remains cursor-gated, matching the Windows implementation.
+                    shouldDetectSelection = true;
+                    detectionType = SelectionDetectType::Drag;
                 }
                 // Check for double-click selection
                 else if (isLastValidClick && isCurrentValidClick && distance <= DOUBLE_CLICK_MAX_DISTANCE)
@@ -1781,8 +1796,19 @@ void SelectionHook::ProcessMouseEvent(Napi::Env env, Napi::Function function, Mo
             mouseTypeStr = "mouse-up";
             break;
 
-        case kCGEventMouseMoved:
         case kCGEventLeftMouseDragged:
+            // Sample the cursor while dragging: a fast drag can press before the app
+            // switches the cursor to I-beam and release outside the text (arrow again),
+            // so both endpoint checks miss. Seeing an I-beam at any point mid-drag
+            // marks the gesture as a valid text-selection candidate.
+            if (!wasIBeamDuringDrag && IsIBeamCursor([NSCursor currentSystemCursor]))
+            {
+                wasIBeamDuringDrag = true;
+            }
+            mouseTypeStr = "mouse-move";
+            break;
+
+        case kCGEventMouseMoved:
         case kCGEventRightMouseDragged:
         case kCGEventOtherMouseDragged:
             mouseTypeStr = "mouse-move";


### PR DESCRIPTION
## Problem

On macOS, selecting text with a quick swipe often fails to emit `text-selection`. Repro: press and drag quickly across a paragraph and release — nothing fires. Selecting the same text slowly works, and so does pausing for a moment before releasing the button.

## Cause

`MouseEventCallback` gates drag detection on the I-beam cursor, sampled at mouse-down and mouse-up. The deeper issue (which also explains the "pause before release" workaround above): **macOS doesn't refresh the cursor shape while the pointer is moving quickly** — apps only update the cursor once the pointer rests. So on a fast swipe the gesture may never show an I-beam at any point, and no amount of extra sampling fixes it. Relying on cursor shape fundamentally cannot catch fast drags.

## Fix

Restructure the macOS gating to match what the Windows implementation already does:

- **Drag detection no longer looks at the cursor shape.** Any qualifying drag (distance >= 8px, within the drag time limit) attempts the AX read. The AX read is side-effect free — if there is no selection it simply returns nothing. This is exactly how `src/windows` has always behaved (it only consults cursor shape for the clipboard decision, never for drag detection).
- **The clipboard fallback stays cursor-gated.** Simulating Cmd+C has real side effects, so it now explicitly requires cursor evidence for the gesture: an I-beam seen at mouse-down, mid-drag (newly sampled on `kCGEventLeftMouseDragged`) or mouse-up (new `gesture_has_cursor_evidence` flag). User-triggered `getCurrentSelection()` is exempt, same as the existing `is_triggered_by_user` semantics on Windows.
- **Double-click and shift-click keep the existing cursor gate.** Those are stationary gestures where the cursor has had time to update, so they were never affected by this bug.

## Behavior notes

- Dragging a scrollbar/titlebar while the focused element still holds an old selection can now emit that selection on macOS — this is the same tradeoff Windows has always had, so the two platforms are now consistent.
- Apps where AX cannot read the selection (clipboard-fallback apps) still require cursor evidence for fast drags — intentionally, to avoid firing Cmd+C from scrollbar drags.

## Testing

On macOS 15 (arm64), Electron host app: fast swipes that previously missed now emit `text-selection`; slow selections, double-click and shift-click behave as before; scrollbar drags without a lingering selection stay silent.